### PR TITLE
Point Brew Release v0.0.8 to The Correct Tag

### DIFF
--- a/Formula/xctestmetrics.rb
+++ b/Formula/xctestmetrics.rb
@@ -1,7 +1,7 @@
 class Xctestmetrics < Formula
   desc "Command-line tool that provides metrics about your project tests"
   homepage "https://github.com/serralvo/XCTestMetrics"
-  url "https://github.com/serralvo/XCTestMetrics.git", :tag => "0.0.7"
+  url "https://github.com/serralvo/XCTestMetrics.git", :tag => "0.0.8"
   version "0.0.8"
   
   depends_on :xcode => ["11.0", :build]


### PR DESCRIPTION
This PR fixes a mismatch between the versions in the `version` and `tag`, for brew releases.